### PR TITLE
Add the ability to work within TouchableHighlight

### DIFF
--- a/lib/LazyloadImage.js
+++ b/lib/LazyloadImage.js
@@ -26,6 +26,10 @@ class LazyloadImage extends LazyloadView{
         ...Image.propTypes
     };
 
+    setNativeProps(nativeProps) {
+      this._root.setNativeProps(nativeProps);
+    }
+
     render() {
         let key = null;
         if (this.props.animation) {


### PR DESCRIPTION
If you want to "touch" on a "lazy-loaded" element we must have a "setNativeProps" method
