### PR TITLE
Update to react native 0.28.0 generate an error

### DIFF
--- a/lib/LazyloadImage.js
+++ b/lib/LazyloadImage.js
@@ -8,7 +8,7 @@ import {
 } from 'react-native';
 import LazyloadView from './LazyloadView';
 import Anim from './Anim';
-const emptySource = Platform.OS === 'ios' ? null : {uri:'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7'};
+const emptySource = {uri:'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7'};
 
 class LazyloadImage extends LazyloadView{
     static displayName = 'LazyloadImage';


### PR DESCRIPTION
If you update your project to react-native 0.28.0, you'll have this error on iOS.

> JSON value '<null>' of type NSNull cannot be converted to NSString
