### PR TITLE
Fix Image component with react-native 0.28

### DIFF
--- a/lib/LazyloadImage.js
+++ b/lib/LazyloadImage.js
@@ -8,7 +8,7 @@ import {
 } from 'react-native';
 import LazyloadView from './LazyloadView';
 import Anim from './Anim';
-const emptySource = Platform.OS === 'ios' ? null : {uri:'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7'};
+const emptySource = {uri: 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7'};
 
 class LazyloadImage extends LazyloadView{
     static displayName = 'LazyloadImage';


### PR DESCRIPTION
React native 0.28 doesn't allow the `source`prop of `Image` to be something like `null` or even `false`.
It would throw an error when trying to convert an NSNull to NSString.
