### PR TITLE
Fix PropTypes error

### DIFF
--- a/lib/Anim.js
+++ b/lib/Anim.js
@@ -1,6 +1,5 @@
-import React, {
-    PropTypes
-} from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import ReactNative, {
    LayoutAnimation
 } from 'react-native';

--- a/lib/LazyloadImage.js
+++ b/lib/LazyloadImage.js
@@ -1,7 +1,7 @@
 import React, {
-    Component,
-    PropTypes
+    Component
 } from 'react';
+import PropTypes from 'prop-types';
 import {
     Image,
     Platform

--- a/lib/LazyloadListView.js
+++ b/lib/LazyloadListView.js
@@ -1,7 +1,7 @@
 import React, {
-    Component,
-    PropTypes
+    Component
 } from 'react';
+import PropTypes from 'prop-types';
 import {
     ListView
 } from 'react-native';

--- a/lib/LazyloadScrollView.js
+++ b/lib/LazyloadScrollView.js
@@ -1,7 +1,7 @@
 import React, {
-    Component,
-    PropTypes
+    Component
 } from 'react';
+import PropTypes from 'prop-types';
 import ReactNative, {
     ScrollView,
     Dimensions

--- a/lib/LazyloadView.js
+++ b/lib/LazyloadView.js
@@ -1,7 +1,7 @@
 import React, {
-    Component,
-    PropTypes
+    Component
 } from 'react';
+import PropTypes from 'prop-types';
 import {
     View,
     LayoutAnimation


### PR DESCRIPTION
PropTypes in React 16 Deprecated. Use the prop-types package from npm instead.